### PR TITLE
Fix deprecations

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -19,7 +19,7 @@
 
 namespace Formatter {
 
-    public class FormatterApp : Granite.Application {
+    public class FormatterApp : Gtk.Application {
 
         static FormatterApp _instance = null;
 
@@ -32,10 +32,7 @@ namespace Formatter {
         }
 
         construct {
-            program_name = "Formatter";
-            exec_name = "com.github.djaler.formatter";
             application_id = "com.github.djaler.formatter";
-            app_launcher = application_id + ".desktop";
         }
 
         Gtk.Window mainwindow;

--- a/src/Widgets/Device.vala
+++ b/src/Widgets/Device.vala
@@ -39,7 +39,7 @@ namespace Formatter {
             icon = get_medium_icon ();
             icon.margin = 6;
             title = new Gtk.Label (d.get_name ());
-            title.margin_right = 6;
+            title.margin_end = 6;
             content.attach (icon, 0, 0, 1, 1);
             content.attach (title, 1, 0, 1, 1);
         }

--- a/src/Widgets/Filesystem.vala
+++ b/src/Widgets/Filesystem.vala
@@ -75,8 +75,8 @@ namespace Formatter {
             title = new Gtk.Label (filesystem.get_name ());
             title.margin_top = 6;
             title.margin_bottom = 6;
-            title.margin_right = 12;
-            title.margin_left = 12;
+            title.margin_start = 12;
+            title.margin_end = 12;
             content.attach (title, 0, 0, 1, 1);
         }
     }


### PR DESCRIPTION
### Changes Summary

* Use `Gtk.Widget.margin_end` instead of `Gtk.Widget.margin_right` ([deprecated since 3.12](https://valadoc.org/gtk+-3.0/Gtk.Widget.margin_right.html))
* Use `Gtk.Widget.margin_start` instead of `Gtk.Widget.margin_left` ([deprecated since 3.12](https://valadoc.org/gtk+-3.0/Gtk.Widget.margin_left.html))
* Use `Gtk.Application` instead of `Granite.Application` ([deprecated since 0.5.0](https://github.com/elementary/granite/blob/e11a7b1561ef2361da4bfbbe917209da36b0b317/lib/Application.vala#L25))
