### PR TITLE
Update packaging for Loki to use meson

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,10 +2,10 @@ Source: com.github.djaler.formatter
 Section: x11
 Priority: optional
 Maintainer: Kirill Romanov <djaler1@gmail.com>
-Build-Depends: cmake (>= 2.8),
-               cmake-elementary,
-               debhelper (>= 9),
+Build-Depends: debhelper (>= 9),
                libgranite-dev,
+               libgtk-3-dev,
+               meson,
                valac (>= 0.26)
 Standards-Version: 3.9.3
 

--- a/debian/rules
+++ b/debian/rules
@@ -12,3 +12,18 @@
 %:
 	dh $@ 
 
+override_dh_auto_clean:
+	rm -rf debian/build
+
+override_dh_auto_configure:
+	mkdir -p debian/build
+	cd debian/build && meson --prefix=/usr ../..
+
+override_dh_auto_build:
+	cd debian/build && ninja -v
+
+override_dh_auto_test:
+	cd debian/build && ninja test
+
+override_dh_auto_install:
+	cd debian/build && DESTDIR=${CURDIR}/debian/com.github.djaler.formatter ninja install


### PR DESCRIPTION
Specify to use Meson as build system in debian packaging, as described https://medium.com/elementaryos/all-aboard-the-meson-future-hype-train-2b6c478b6b9e and https://github.com/danrabbit/harvey/blob/2782727e56328bbc98e8633624b084f5919d1985/debian/rules
