### PR TITLE
Update packaging for Juno to use meson

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,10 +2,10 @@ Source: com.github.djaler.formatter
 Section: x11
 Priority: optional
 Maintainer: Kirill Romanov <djaler1@gmail.com>
-Build-Depends: cmake (>= 2.8),
-               cmake-elementary,
-               debhelper (>= 9),
+Build-Depends: debhelper (>= 9),
                libgranite-dev,
+               libgtk-3-dev,
+               meson,
                valac (>= 0.26)
 Standards-Version: 3.9.3
 


### PR DESCRIPTION
Specify to use Meson as build system in debian packaging, as described https://medium.com/elementaryos/all-aboard-the-meson-future-hype-train-2b6c478b6b9e
