### PR TITLE
Fix coding style

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -20,18 +20,20 @@
 namespace Formatter {
 
     public class FormatterApp : Gtk.Application {
-
-        static FormatterApp _instance = null;
-
-        public static Settings settings;
-
+        private static FormatterApp _instance = null;
         public static FormatterApp instance {
             get {
-                if (_instance == null)
+                if (_instance == null) {
                     _instance = new FormatterApp ();
+                }
+
                 return _instance;
             }
         }
+
+        private MainWindow mainwindow;
+
+        public static Settings settings;
 
         construct {
             application_id = "com.github.djaler.formatter";
@@ -41,8 +43,6 @@ namespace Formatter {
             settings = new Settings ("com.github.djaler.formatter");
         }
 
-        Gtk.Window mainwindow;
-
         protected override void activate () {
             if (mainwindow != null) {
                 mainwindow.present ();
@@ -50,7 +50,7 @@ namespace Formatter {
             }
 
             mainwindow = new MainWindow ();
-            mainwindow.set_application(this);
+            mainwindow.set_application (this);
         }
     }
 }

--- a/src/Objects/DeviceFormatter.vala
+++ b/src/Objects/DeviceFormatter.vala
@@ -20,17 +20,27 @@
 namespace Formatter {
 
     public class DeviceFormatter : GLib.Object {
+        public signal void begin ();
+        public signal void canceled ();
+        public signal void finished (bool success);
 
-        static DeviceFormatter _instance = null;
+        private static DeviceFormatter _instance = null;
         public static DeviceFormatter instance {
             get {
-                if (_instance == null)
+                if (_instance == null) {
                     _instance = new DeviceFormatter ();
+                }
+
                 return _instance;
             }
         }
 
-        private DeviceFormatter () {}
+        public bool is_running { get; private set; }
+
+        private Pid child_pid;
+
+        private DeviceFormatter () {
+        }
 
         construct {
             this.is_running = false;
@@ -48,15 +58,7 @@ namespace Formatter {
             });
         }
 
-        public bool is_running {get;set;}
-
-        public signal void begin ();
-        public signal void canceled ();
-        public signal void finished (bool success);
-
-        Pid child_pid;
-
-        public async void format_partition(Drive drive, Formatter.Filesystems filesystem, string label) {
+        public async void format_partition (Drive drive, Formatter.Filesystems filesystem, string label) {
             string[] spawn_args;
 
             string drive_identifier = drive.get_identifier ("unix-device");
@@ -104,7 +106,7 @@ namespace Formatter {
                     }
                     break;
                 default:
-                    assert_not_reached();
+                    assert_not_reached ();
             }
 
             int standard_error = 0;

--- a/src/Widgets/Device.vala
+++ b/src/Widgets/Device.vala
@@ -18,11 +18,10 @@
  */
 
 namespace Formatter {
-    public class Device : Gtk.FlowBoxChild  {
-
-        Gtk.Grid content;
-        Gtk.Image icon;
-        Gtk.Label title;
+    public class Device : Gtk.FlowBoxChild {
+        private Gtk.Grid content;
+        private Gtk.Image icon;
+        private Gtk.Label title;
 
         public GLib.Drive drive { get; private set; }
 
@@ -53,22 +52,12 @@ namespace Formatter {
         }
 
         // METHODS
-        public string get_unix_device () {
-            return drive.get_identifier ("unix-device");
-        }
-
         public Gtk.Image get_medium_icon () {
             if (is_card) {
                 return new Gtk.Image.from_icon_name ("media-flash", Gtk.IconSize.LARGE_TOOLBAR);
             }
-            return new Gtk.Image.from_gicon (drive.get_icon (), Gtk.IconSize.LARGE_TOOLBAR);
-        }
 
-        public Gtk.Image get_large_icon () {
-            if (is_card) {
-                return new Gtk.Image.from_icon_name ("media-flash", Gtk.IconSize.DIALOG);
-            }
-            return new Gtk.Image.from_gicon (drive.get_icon (), Gtk.IconSize.DIALOG);
+            return new Gtk.Image.from_gicon (drive.get_icon (), Gtk.IconSize.LARGE_TOOLBAR);
         }
 
         public void umount_all_volumes () {

--- a/src/Widgets/Filesystem.vala
+++ b/src/Widgets/Filesystem.vala
@@ -26,58 +26,50 @@ namespace Formatter {
         NTFS,
         HFS_PLUS;
 
-        public string get_name() {
+        public string get_name () {
             switch (this) {
                 case EXT4:
                     return "ext4";
-
                 case FAT16:
                     return "FAT16";
-
                 case FAT32:
                     return "FAT32";
-
                 case NTFS:
                     return "NTFS";
-
                 case EXFAT:
                     return "exFAT";
-
                 case HFS_PLUS:
                     return "HFS+";
-
                 default:
-                    assert_not_reached();
+                    assert_not_reached ();
             }
         }
 
-        public static Filesystems[] get_all() {
+        public static Filesystems[] get_all () {
             return { FAT32, FAT16, EXFAT, EXT4, NTFS, HFS_PLUS };
         }
     }
 
-    public class Filesystem : Gtk.FlowBoxChild  {
-        Gtk.Grid content;
-        Gtk.Label title;
-
+    public class Filesystem : Gtk.FlowBoxChild {
         public Filesystems filesystem { get; private set; }
 
-        construct {
-            content = new Gtk.Grid ();
-            content.row_spacing = 12;
-            content.valign = Gtk.Align.CENTER;
-            this.add (content);
+        public Filesystem (Filesystems filesystem) {
+            Object (filesystem: filesystem);
         }
 
-        public Filesystem (Filesystems filesystem) {
-            this.filesystem = filesystem;
-
-            title = new Gtk.Label (filesystem.get_name ());
+        construct {
+            var title = new Gtk.Label (filesystem.get_name ());
             title.margin_top = 6;
             title.margin_bottom = 6;
             title.margin_start = 12;
             title.margin_end = 12;
+
+            var content = new Gtk.Grid ();
+            content.row_spacing = 12;
+            content.valign = Gtk.Align.CENTER;
             content.attach (title, 0, 0, 1, 1);
+
+            this.add (content);
         }
     }
 }


### PR DESCRIPTION
## Changes Summary
Overall, I tried to follow [the elementary coding style](https://elementary.io/docs/code/reference#code-style).

* Explicit `private`
* Always use brackets even if there is only one line in an `if` statement
* Newline after closing brackets except when followed by another closing bracket or an else statement
* Don't declare an instance of MainWindow as Gtk.Window
* Space before a paren
* Use `construct` sentence instead of the one-time-used `build_ui` method
* Reversed condition to avoid nesting `if` statement
* Fix long lines (over 120 words)
* Signals at the beginning of the class
* Use 4 spaces instead of tabs for indentations
* Spaces in properties
* Lesser scope when possible (`private set`)
* Remove an extra space before a bracket
* Remove unused methods
* Use GObject construction

If you feel this PR contains too many changes at the same time, please let me know so that I'll separate it into several ones.
