### PR TITLE
Fix a warning about an unwritable property

### DIFF
--- a/src/Widgets/Filesystem.vala
+++ b/src/Widgets/Filesystem.vala
@@ -51,7 +51,7 @@ namespace Formatter {
     }
 
     public class Filesystem : Gtk.FlowBoxChild {
-        public Filesystems filesystem { get; private set; }
+        public Filesystems filesystem { get; set; }
 
         public Filesystem (Filesystems filesystem) {
             Object (filesystem: filesystem);


### PR DESCRIPTION
```
(com.github.djaler.formatter:10804): GLib-GObject-CRITICAL **: 22:05:47.065: g_object_new_is_valid_property: property 'filesystem' of object class 'FormatterFilesystem' is not writable
```

Seems like a small regression of #58
